### PR TITLE
fixed issue if death has length of 0 

### DIFF
--- a/dispersal.R
+++ b/dispersal.R
@@ -98,7 +98,7 @@ dispersal <- function(N, B, p, q, b, m, no_plot=FALSE) {
     
     ## mortality for the ones who moved
     death <- which(as.logical((runif(nrow(newpop)) < m) * move))
-    newpop <- newpop[-death,]
+    if (length(death) != 0) newpop <- newpop[-death,]
     
     ## the new generation is ready
     pop <- newpop


### PR DESCRIPTION
fixed issue if death has length of 0 (caused newpop to remove all observations, and subsequently end simulation prematurely)